### PR TITLE
chore: use skillet instead of zod, nodejs instead of edge, and gpt-4.1

### DIFF
--- a/app/api/generate/route.js
+++ b/app/api/generate/route.js
@@ -1,24 +1,22 @@
 import { NextResponse } from 'next/server'
 import { HashbrownOpenAI } from '@hashbrownai/openai'
-import { generateRequestSchema } from '../../../lib/schemas.js'
 import { layoutSchema } from '../../../hb/schema.js'
 
-export const runtime = 'edge'
+export const runtime = 'nodejs'
 
 export async function POST(request) {
   try {
     const body = await request.json()
     
     // Validate request
-    const validation = generateRequestSchema.safeParse(body)
-    if (!validation.success) {
+    if (!body.prompt || typeof body.prompt !== 'string') {
       return NextResponse.json(
-        { error: 'Invalid request format', details: validation.error.errors },
+        { error: 'Invalid request format: prompt is required and must be a string' },
         { status: 400 }
       )
     }
 
-    const { prompt } = validation.data
+    const { prompt } = body
     
     const OPENAI_API_KEY = process.env.OPENAI_API_KEY
     if (!OPENAI_API_KEY) {
@@ -34,7 +32,7 @@ export async function POST(request) {
     Structure your response using the provided schema for better presentation.`
 
     const completionParams = {
-      model: 'gpt-4o-mini',
+      model: 'gpt-4.1',
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: prompt }

--- a/hb/exposed-components.jsx
+++ b/hb/exposed-components.jsx
@@ -1,5 +1,4 @@
 import { exposeComponent } from '@hashbrownai/react'
-import { s } from '@hashbrownai/core'
 import { IngredientTextInput } from './components/IngredientTextInput.jsx'
 import { QuickSelectChips } from './components/QuickSelectChips.jsx'
 import { RecipeCard } from './components/RecipeCard.jsx'
@@ -10,7 +9,7 @@ export const exposedComponents = [
     name: 'IngredientTextInput',
     description: 'A text input component for entering ingredients',
     props: {
-      placeholder: s.string('Placeholder text for the input'),
+      placeholder: 'string',
     },
     // onIngredientsChange callback is handled internally
   }),
@@ -19,7 +18,7 @@ export const exposedComponents = [
     name: 'QuickSelectChips',
     description: 'Pill-shaped buttons for quickly selecting common breakfast ingredients',
     props: {
-      selectedIngredients: s.array('Array of currently selected ingredients', s.string()),
+      selectedIngredients: 'array',
     },
     // onSelectionChange callback is handled internally
   }),
@@ -28,17 +27,7 @@ export const exposedComponents = [
     name: 'RecipeCard',
     description: 'A card component that displays a complete recipe with ingredients, directions, and save functionality',
     props: {
-      recipe: s.object('Recipe object', {
-        title: s.string('Recipe title'),
-        name: s.string('Recipe name (alternative to title)'),
-        description: s.string('Recipe description'),
-        ingredients: s.array('List of ingredients', s.string()),
-        directions: s.array('List of cooking directions', s.string()),
-        instructions: s.array('List of cooking instructions (alternative to directions)', s.string()),
-        servings: s.string('Number of servings'),
-        time: s.string('Total cooking time'),
-        prepTime: s.string('Preparation time'),
-      }),
+      recipe: 'object',
     },
     // onSave callback is handled internally
   }),
@@ -75,8 +64,8 @@ export const allExposedComponents = [
     description: 'Show a card with title, description and children components',
     children: 'any',
     props: {
-      title: s.string('The title of the card'),
-      description: s.string('The description of the card'),
+      title: 'string',
+      description: 'string',
     },
   }),
 ]

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,157 +1,43 @@
-import { z } from 'zod'
+import { s } from '@hashbrownai/core'
 
-export const generateRequestSchema = z.object({
-  prompt: z.string()
-    .min(1, 'Prompt is required')
-    .max(2000, 'Prompt must be less than 2000 characters')
-    .refine(
-      (prompt) => prompt.trim().length > 0,
-      'Prompt cannot be empty or just whitespace'
-    ),
-  
-  options: z.object({
-    temperature: z.number().min(0).max(2).optional(),
-    maxTokens: z.number().min(1).max(4000).optional(),
-    includeNutrition: z.boolean().optional(),
-    dietaryRestrictions: z.array(z.string()).optional(),
-    complexity: z.enum(['simple', 'moderate', 'complex']).optional(),
-    contentType: z.enum(['recipe', 'menu', 'story', 'tips', 'mixed']).optional()
-  }).optional()
+export const generateRequestSchema = s.object('Generate request', {
+  prompt: s.string('The user prompt for content generation')
 })
 
-export const recipeIngredientSchema = z.object({
-  name: z.string().min(1, 'Ingredient name is required'),
-  amount: z.string().optional(),
-  unit: z.string().optional(),
-  notes: z.string().optional(),
-  isOptional: z.boolean().default(false)
+export const recipeIngredientSchema = s.object('Recipe ingredient', {
+  name: s.string('Ingredient name')
 })
 
-export const recipeInstructionSchema = z.object({
-  step: z.number().min(1),
-  instruction: z.string().min(1, 'Instruction text is required'),
-  duration: z.string().optional(),
-  temperature: z.string().optional(),
-  tips: z.array(z.string()).optional()
+export const recipeInstructionSchema = s.object('Recipe instruction', {
+  step: s.number('Step number'),
+  instruction: s.string('Instruction text')
 })
 
-export const recipeSchema = z.object({
-  title: z.string().min(1, 'Recipe title is required'),
-  description: z.string().optional(),
-  servings: z.string().or(z.number()).optional(),
-  prepTime: z.string().optional(),
-  cookTime: z.string().optional(),
-  totalTime: z.string().optional(),
-  difficulty: z.enum(['easy', 'medium', 'hard']).optional(),
-  
-  ingredients: z.array(recipeIngredientSchema).min(1, 'At least one ingredient is required'),
-  instructions: z.array(recipeInstructionSchema).min(1, 'At least one instruction is required'),
-  
-  nutrition: z.object({
-    calories: z.number().min(0).optional(),
-    protein: z.number().min(0).optional(),
-    carbs: z.number().min(0).optional(),
-    fat: z.number().min(0).optional(),
-    fiber: z.number().min(0).optional(),
-    sugar: z.number().min(0).optional(),
-    sodium: z.number().min(0).optional()
-  }).optional(),
-  
-  tags: z.array(z.string()).optional(),
-  cuisine: z.string().optional(),
-  category: z.array(z.string()).optional(),
-  
-  tips: z.array(z.string()).optional(),
-  variations: z.array(z.string()).optional(),
-  storage: z.string().optional(),
-  
-  allergens: z.array(z.enum([
-    'dairy', 'eggs', 'gluten', 'nuts', 'soy', 'shellfish', 'fish', 'sesame'
-  ])).optional()
+export const recipeSchema = s.object('Recipe', {
+  title: s.string('Recipe title'),
+  ingredients: s.array('Recipe ingredients', recipeIngredientSchema),
+  instructions: s.array('Recipe instructions', recipeInstructionSchema)
 })
 
-export const menuItemSchema = z.object({
-  name: z.string().min(1, 'Menu item name is required'),
-  description: z.string().optional(),
-  price: z.string().optional(),
-  category: z.string().optional(),
-  
-  allergens: z.array(z.string()).optional(),
-  dietaryTags: z.array(z.enum([
-    'vegetarian', 'vegan', 'gluten-free', 'dairy-free', 'keto', 'paleo', 'low-carb', 'high-protein'
-  ])).optional(),
-  
-  spiceLevel: z.enum(['mild', 'medium', 'hot', 'very-hot']).optional(),
-  availability: z.enum(['always', 'seasonal', 'weekend-only', 'limited']).optional(),
-  
-  nutrition: z.object({
-    calories: z.number().optional(),
-    protein: z.number().optional(),
-    carbs: z.number().optional(),
-    fat: z.number().optional()
-  }).optional()
+export const menuItemSchema = s.object('Menu item', {
+  name: s.string('Menu item name')
 })
 
-export const menuSectionSchema = z.object({
-  title: z.string().min(1, 'Menu section title is required'),
-  description: z.string().optional(),
-  items: z.array(menuItemSchema).min(1, 'At least one menu item is required'),
-  displayOrder: z.number().optional()
+export const menuSectionSchema = s.object('Menu section', {
+  title: s.string('Section title'),
+  items: s.array('Menu items', menuItemSchema)
 })
 
-export const nutritionFactsSchema = z.object({
-  servingSize: z.string().optional(),
-  servingsPerContainer: z.number().optional(),
-  
-  calories: z.number().min(0).optional(),
-  caloriesFromFat: z.number().min(0).optional(),
-  
-  totalFat: z.number().min(0).optional(),
-  saturatedFat: z.number().min(0).optional(),
-  transFat: z.number().min(0).optional(),
-  
-  cholesterol: z.number().min(0).optional(),
-  sodium: z.number().min(0).optional(),
-  
-  totalCarbs: z.number().min(0).optional(),
-  dietaryFiber: z.number().min(0).optional(),
-  sugars: z.number().min(0).optional(),
-  addedSugars: z.number().min(0).optional(),
-  
-  protein: z.number().min(0).optional(),
-  
-  vitaminA: z.number().min(0).optional(),
-  vitaminC: z.number().min(0).optional(),
-  calcium: z.number().min(0).optional(),
-  iron: z.number().min(0).optional(),
-  
-  percentDailyValues: z.record(z.string(), z.number()).optional()
+export const nutritionFactsSchema = s.object('Nutrition facts', {
+  calories: s.number('Calories')
 })
 
-export const tipSchema = z.object({
-  title: z.string().min(1, 'Tip title is required'),
-  content: z.string().min(1, 'Tip content is required'),
-  category: z.enum(['cooking', 'prep', 'storage', 'nutrition', 'technique', 'ingredient', 'equipment']).optional(),
-  difficulty: z.enum(['beginner', 'intermediate', 'advanced']).optional(),
-  tags: z.array(z.string()).optional()
+export const tipSchema = s.object('Cooking tip', {
+  title: s.string('Tip title'),
+  content: s.string('Tip content')
 })
 
-export const storySchema = z.object({
-  title: z.string().min(1, 'Story title is required'),
-  content: z.union([
-    z.string(),
-    z.array(z.string())
-  ]).refine(
-    (content) => {
-      if (typeof content === 'string') return content.trim().length > 0
-      return Array.isArray(content) && content.length > 0 && content.every(p => p.trim().length > 0)
-    },
-    'Story content cannot be empty'
-  ),
-  author: z.string().optional(),
-  mood: z.enum(['nostalgic', 'humorous', 'heartwarming', 'adventurous', 'cozy', 'inspiring']).optional(),
-  setting: z.string().optional(),
-  characters: z.array(z.string()).optional(),
-  theme: z.string().optional(),
-  wordCount: z.number().min(0).optional()
+export const storySchema = s.object('Breakfast story', {
+  title: s.string('Story title'),
+  content: s.string('Story content')
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "hashbrowns-breakfast-app",
+  "name": "breakfast-brain",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "hashbrowns-breakfast-app",
+      "name": "breakfast-brain",
       "version": "0.1.0",
       "dependencies": {
         "@hashbrownai/core": "0.2.3",
@@ -18,8 +18,7 @@
         "@radix-ui/react-toast": "^1.2.0",
         "next": "15.5.2",
         "react": "18.3.1",
-        "react-dom": "18.3.1",
-        "zod": "^3.23.0"
+        "react-dom": "18.3.1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.0",
@@ -10178,6 +10177,8 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@hashbrownai/react": "0.2.3",
     "@hashbrownai/core": "0.2.3",
     "@hashbrownai/openai": "0.2.3",
-    "zod": "^3.23.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-switch": "^1.1.0",
     "@radix-ui/react-label": "^2.1.0",


### PR DESCRIPTION
This pull request refactors how schemas are defined and validated throughout the codebase, moving from the `zod` library to the `@hashbrownai/core` schema utilities. It also simplifies the way exposed component props are described and updates the OpenAI model used for completions. These changes aim to streamline schema management, improve consistency with the broader `@hashbrownai` ecosystem, and remove an external dependency.

**Schema system migration and simplification:**

* Replaced all `zod`-based schemas in `lib/schemas.js` with schema definitions using `s` from `@hashbrownai/core`, greatly simplifying and unifying schema definitions for requests, recipes, menus, nutrition facts, tips, and stories. (`lib/schemas.js`)
* Removed the dependency on `zod` from `package.json`.

**API validation and runtime changes:**

* Updated the request validation logic in `app/api/generate/route.js` to use a basic prompt check instead of the previous `generateRequestSchema.safeParse`, reflecting the new simpler schema. Also changed the runtime from `edge` to `nodejs` for compatibility.

**Component prop type simplification:**

* Simplified the way component prop types are described in `hb/exposed-components.jsx`, replacing the use of `s` schema helpers with plain strings or type descriptors (e.g., `'string'`, `'array'`, `'object'`). (`hb/exposed-components.jsx`) [[1]](diffhunk://#diff-a57b3d0ea221629fdde98f8da9c809b8fd93cf5636c73f79642ce94aa729f6f9L13-R12) [[2]](diffhunk://#diff-a57b3d0ea221629fdde98f8da9c809b8fd93cf5636c73f79642ce94aa729f6f9L22-R21) [[3]](diffhunk://#diff-a57b3d0ea221629fdde98f8da9c809b8fd93cf5636c73f79642ce94aa729f6f9L31-R30) [[4]](diffhunk://#diff-a57b3d0ea221629fdde98f8da9c809b8fd93cf5636c73f79642ce94aa729f6f9L78-R68)

**OpenAI model update:**

* Changed the OpenAI model used in completions from `'gpt-4o-mini'` to `'gpt-4.1'` in `app/api/generate/route.js`.